### PR TITLE
Run the EventEmitter constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ var util = require('util');
 var pg = require('pg');
 
 var PGPubsub = function (conString, options) {
+  EventEmitter.call(this);
   var self = this;
 
   this.setMaxListeners(0);


### PR DESCRIPTION
Since PGPubsub is extending EventEmitter, it should call the EventEmitter's constructor to ensure that any internal bookkeeping or setup is performed.