### PR TITLE
Wrap channel names with double quotations.

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ var PGPubsub = function (conString, options) {
       db.on('notification', self._processNotification.bind(self));
 
       self.channels.forEach(function (channel) {
-        db.query('LISTEN ' + channel);
+        db.query('LISTEN "' + channel + '"');
       });
     },
     end: function (db) {
@@ -81,7 +81,7 @@ PGPubsub.prototype.addChannel = function (channel, callback) {
     this.channels.push(channel);
 
     this._getDB(function (db) {
-      db.query('LISTEN ' + channel);
+      db.query('LISTEN "' + channel + '"');
     });
   }
 
@@ -108,7 +108,7 @@ PGPubsub.prototype.removeChannel = function (channel, callback) {
   if (this.listeners(channel).length === 0) {
     this.channels.splice(pos, 1);
     this._getDB(false, function (db) {
-      db.query('UNLISTEN ' + channel);
+      db.query('UNLISTEN "' + channel + '"');
     });
   }
 
@@ -117,7 +117,7 @@ PGPubsub.prototype.removeChannel = function (channel, callback) {
 
 PGPubsub.prototype.publish = function (channel, data) {
   this._getDB(function (db) {
-    db.query('NOTIFY ' + channel +  ', \'' + JSON.stringify(data) + '\'');
+    db.query('NOTIFY "' + channel +  '", \'' + JSON.stringify(data) + '\'');
   });
 };
 

--- a/test/integration/main.spec.js
+++ b/test/integration/main.spec.js
@@ -42,7 +42,7 @@ describe('Pubsub', function () {
       });
 
       setImmediate(function () {
-        db.query('NOTIFY foobar, \'{"abc":123}\'');
+        db.query('NOTIFY "foobar", \'{"abc":123}\'');
       });
     });
 
@@ -53,7 +53,18 @@ describe('Pubsub', function () {
       });
 
       setImmediate(function () {
-        db.query('NOTIFY foobar, \'barfoo\'');
+        db.query('NOTIFY "foobar", \'barfoo\'');
+      });
+    });
+
+    it('should handle non-alphanumeric channels', function (done) {
+      pubsubInstance.addChannel('97a38cd1-d332-4240-93e4-1ff436a7da2a', function (channelPayload) {
+        channelPayload.should.deep.equal({ 'non-alpha': true });
+        done();
+      });
+
+      setImmediate(function () {
+        db.query('NOTIFY "97a38cd1-d332-4240-93e4-1ff436a7da2a", \'{"non-alpha":true}\'');
       });
     });
 
@@ -68,9 +79,9 @@ describe('Pubsub', function () {
       });
 
       setImmediate(function () {
-        db.query('NOTIFY def, \'{"ghi":456}\'');
-        db.query('NOTIFY foo, \'{"abc":123}\'');
-        db.query('NOTIFY bar, \'{"xyz":789}\'');
+        db.query('NOTIFY "def", \'{"ghi":456}\'');
+        db.query('NOTIFY "foo", \'{"abc":123}\'');
+        db.query('NOTIFY "bar", \'{"xyz":789}\'');
       });
     });
 
@@ -90,8 +101,8 @@ describe('Pubsub', function () {
       pubsubInstance.removeChannel('foo');
 
       setImmediate(function () {
-        db.query('NOTIFY foo, \'{"abc":123}\'');
-        db.query('NOTIFY bar, \'{"xyz":789}\'');
+        db.query('NOTIFY "foo", \'{"abc":123}\'');
+        db.query('NOTIFY "bar", \'{"xyz":789}\'');
       });
     });
 
@@ -107,7 +118,7 @@ describe('Pubsub', function () {
       });
 
       setImmediate(function () {
-        db.query('NOTIFY foobar, \'{"abc":123}\'');
+        db.query('NOTIFY "foobar", \'{"abc":123}\'');
       });
     });
 
@@ -125,7 +136,7 @@ describe('Pubsub', function () {
       pubsubInstance.removeChannel('foobar', listener);
 
       setImmediate(function () {
-        db.query('NOTIFY foobar, \'{"abc":123}\'');
+        db.query('NOTIFY "foobar", \'{"abc":123}\'');
       });
     });
 
@@ -137,7 +148,7 @@ describe('Pubsub', function () {
       });
 
       setImmediate(function () {
-        db.query('NOTIFY foobar, \'{"abc":123}\'');
+        db.query('NOTIFY "foobar", \'{"abc":123}\'');
       });
     });
 
@@ -152,7 +163,7 @@ describe('Pubsub', function () {
 
         pubsubInstance._getDB(function (db) {
           setImmediate(function () {
-            db.query('NOTIFY foobar, \'{"abc":123}\'');
+            db.query('NOTIFY "foobar", \'{"abc":123}\'');
           });
         });
       });


### PR DESCRIPTION
This allows the channel name to have non-alphanumeric values in it (such as a UUID containing hyphens).

As an aside, I couldn't force a failing test to see `DATABASE_TEST_URL=xxx npm test` fail. I added a test that _should_ fail without the patch and _should_ pass with it. But in all honesty, I didn't see it go red first.