### PR TITLE
Allow for better control over connection issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "lodash": "^3.0.0",
     "pg": "^4.4.1",
-    "promised-retry": "^0.2.1"
+    "promised-retry": "^0.2.3"
   },
   "engines": {
     "node": ">=0.12.0",

--- a/test/integration/main.spec.js
+++ b/test/integration/main.spec.js
@@ -33,6 +33,20 @@ describe('Pubsub', function () {
     pubsubInstance.close();
   });
 
+  describe('connection', function () {
+    it('should not attempt reconnecting if instructed', function (done) {
+      pubsubInstance = new PGPubsub('postgres://postgress@host.invalid', {
+        log: function () {},
+        retryLimit: 0
+      });
+
+      pubsubInstance.retry.try()
+        .catch(function () {
+          done();
+        });
+    });
+  });
+
   describe('receive', function () {
 
     it('should receive a notification', function (done) {


### PR DESCRIPTION
Previously, the error handler on the pg.Client would cause an infinite connection loop. Additionally, the connection would be retried infinitely either way, because the amount of reconnection attempts could not be limited.
Closes #5