### PR TITLE
Reconnection attempts not properly delayed

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,9 +28,7 @@ var PGPubsub = function (conString, options) {
       var db = new pg.Client(self.conString);
       db.on('error', function () {
         self.retry.reset();
-        if (self.channels.length) {
-          self.retry.try();
-        }
+        self.retry.try();
       });
       return new Promise(function (resolve, reject) {
         db.connect(function (err) {

--- a/index.js
+++ b/index.js
@@ -27,7 +27,6 @@ var PGPubsub = function (conString, options) {
     try: function () {
       var db = new pg.Client(self.conString);
       db.on('error', function () {
-        self.retry.reset();
         self.retry.try();
       });
       return new Promise(function (resolve, reject) {
@@ -41,6 +40,8 @@ var PGPubsub = function (conString, options) {
       });
     },
     success: function (db) {
+      self.retry.reset();
+
       db.on('notification', self._processNotification.bind(self));
 
       self.channels.forEach(function (channel) {


### PR DESCRIPTION
Reconnection attempts are now properly delayed and connections are maintained even if no channels are established.

The reasoning here is, when you instantiate pg-pubsub, it will establish a connection, regardless if channels are or will be establish. So it should also maintain the connection and attempt to reestablish it whenever possible.

The module will now detect lost connections in all scenarios and reestablish the connection while respecting delays. After a successful connection, newly lost connections are also properly reestablished.