### PR TITLE
Update pg version to support postgres 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@types/pg": "^7.4.14",
-    "pg": "^7.4.3",
+    "@types/pg": "^7.14.4",
+    "pg": "^8.3.0",
     "pg-format": "^1.0.2",
     "promised-retry": "^0.3.0",
     "verror": "^1.10.0"


### PR DESCRIPTION
Updating the pg version lets us use newer versions of postgres. I tested this on postgres 12.3.

The previous version of "pg" in packages.json (7.4.3) just does nothing (doesn't resolve, and doesn't reject, even after 5 mins) when trying to connect to a postgres 12.X server.

Ran the tests as described with docker. All pass and one skips, which seems intended. I did run them a few times and noticed a sporadic unhandled rejection warning, which looks like it's due to the first test that tests an erroneous database user, however that did not fail the test suite.

I updated the "@types/pg" package to the latest available, but I didn't see anything for 8.X. Unsure if that is a problem.