### PR TITLE
If the server closes the connection, there will be no error sent when…

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -49,7 +49,7 @@ const pgClientRetry = (options) => {
         retry.reset();
         if (shouldReconnect && shouldReconnect()) retry.try();
         client.end(err => {
-          log('Received error when disconnecting from database in error callback:' + err.message);
+          log('Received error when disconnecting from database in error callback: ' + (err && err.message));
         });
       });
 


### PR DESCRIPTION
… calling db.end(). This checks that the error exists before calling `.message` on it.